### PR TITLE
Resolve setup.py lints, add 'new' flag for repo creation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,19 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 import argparse
-import shutil
 import os
+import shutil
 import subprocess
+import sys
+
 
 BW_GITHUB_PATH = 'git@github.com:BourbonWarfare/potato_{}.git'
 THIS_PATH = os.path.dirname(os.path.realpath(__file__))
 REPO_SYMLINK_PATH_UNFORMATTED = 'potato/{}'
+
 
 def has_requirements():
     if shutil.which('git') is None:
@@ -30,11 +35,13 @@ def has_requirements():
 
     return True
 
+
 def is_path(potential_path):
     if os.path.isdir(potential_path):
         return potential_path
-    else:
-        raise NotADirectoryError(potential_path)
+
+    raise NotADirectoryError(potential_path)
+
 
 def link_directories(repo_path):
     try:
@@ -51,46 +58,77 @@ def link_directories(repo_path):
     print('Linking "{}" to "{}"'.format(repo_path, symlink_path)) 
     os.symlink(repo_path, symlink_path)
 
+
 def clone_repo(clone_path, repository):
     repo_name = "potato_" + repository
     repo_path = os.path.join(clone_path, repo_name)
 
-    subprocess.run(['git', 'clone', BW_GITHUB_PATH.format(repository), repo_path])
-    link_directories(repo_path)
+    try:
+        subprocess.run(['git', 'clone', BW_GITHUB_PATH.format(repository), repo_path],
+                       check=False)
+        link_directories(repo_path)
+    except:
+        print("Error cloning {} to {}!".format(
+            BW_GITHUB_PATH.format(repository), repo_path))
+
 
 def create_repo(clone_path, repository):
     print("Not implemented")
 
+
 def link(args):
     link_directories(args.repositories[0])
-    
+
+
 def add(args):
     args.path = os.path.join(args.path, 'potato_field')
 
     for repo in args.repositories:
-        clone_repo(args.path, repo)
-
-if not has_requirements():
-    exit()
-
-parser = argparse.ArgumentParser(
-        prog = 'setup.py',
-        description = 'Manages the setup of any repository that falls under potato_field',
-        epilog = """
-    potato_field_manager  Copyright (C) 2022  Bailey Danyluk
-    This program comes with ABSOLUTELY NO WARRANTY.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions."""
-)
-
-parser.add_argument('mode', choices=['link', 'add'], default='add', help='Whether to setup a new repository or link an existing one')
-parser.add_argument('repositories', nargs='+', help='Select which repositories to clone and setup')
-parser.add_argument('--path', '-p', required=False, type=is_path, default=os.path.dirname(os.path.realpath(__file__)), help='The directory where the repository will be cloned to. If not specified, repository will be cloned within the directory this tool is run')
-args = parser.parse_args()
-
-if args.mode == 'link':
-    link(args)
-elif args.mode == 'add':
-    add(args)
+        if args.new:
+            create_repo(args.path, repo)
+        else:
+            clone_repo(args.path, repo)
 
 
+def main():
+    if not has_requirements():
+        sys.exit(1)
+
+    parser = argparse.ArgumentParser(
+        prog='setup.py',
+        description='Manages the setup of any repository that falls under potato_field',
+        epilog="""
+        potato_field_manager  Copyright (C) 2022  Bailey Danyluk
+        This program comes with ABSOLUTELY NO WARRANTY.
+        This is free software, and you are welcome to redistribute it
+        under certain conditions."""
+    )
+
+    parser.add_argument(
+        'mode',
+        choices=['link', 'add'],
+        default='add',
+        help='Whether to setup a new repository or link an existing one')
+    parser.add_argument('repositories',
+                        nargs='+',
+                        help='Select which repositories to clone and setup')
+    parser.add_argument('--path', '-p',
+                        nargs=1,
+                        required=False,
+                        type=is_path,
+                        default=os.path.dirname(os.path.realpath(__file__)),
+                        help='The directory where the repository will be cloned to. If not \
+                        specified, repository will be cloned within the directory this tool is run')
+    parser.add_argument('--new',
+                        required=False,
+                        default=False)
+    args = parser.parse_args()
+
+    if args.mode == 'link':
+        link(args)
+    elif args.mode == 'add':
+        add(args)
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,17 @@ THIS_PATH = os.path.dirname(os.path.realpath(__file__))
 REPO_SYMLINK_PATH_UNFORMATTED = 'potato/{}'
 
 
-def has_requirements():
-    if shutil.which('git') is None:
-        return False
+def missing_requirements():
+    '''Returns a list of missing requirements; the empty list is returned
+    if all requirements are satisfied.'''
 
-    return True
+    reqs = ['git']
+
+    res = []
+    for req in reqs:
+        if shutil.which(req) is None:
+            res.append(req)
+    return res
 
 
 def is_path(potential_path):
@@ -46,7 +52,7 @@ def is_path(potential_path):
 def link_directories(repo_path):
     try:
         is_path(repo_path)
-    except:
+    except NotADirectoryError:
         print('"{}" is not a valid path to symlink!'.format(repo_path))
         return
 
@@ -67,9 +73,9 @@ def clone_repo(clone_path, repository):
         subprocess.run(['git', 'clone', BW_GITHUB_PATH.format(repository), repo_path],
                        check=False)
         link_directories(repo_path)
-    except:
-        print("Error cloning {} to {}!".format(
-            BW_GITHUB_PATH.format(repository), repo_path))
+    except Exception as e:
+        print("Error cloning {} to {}: {}!".format(
+            BW_GITHUB_PATH.format(repository), repo_path, e))
 
 
 def create_repo(clone_path, repository):
@@ -91,7 +97,10 @@ def add(args):
 
 
 def main():
-    if not has_requirements():
+    missing = missing_requirements()
+    if len(missing) > 0:
+        print("The following requirements are missing:", missing)
+        print("Exiting...")
         sys.exit(1)
 
     parser = argparse.ArgumentParser(

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,8 @@ def main():
                         specified, repository will be cloned within the directory this tool is run')
     parser.add_argument('--new',
                         required=False,
-                        default=False)
+                        default=False,
+                        help='Create the repository instead of cloning an existing repository')
     args = parser.parse_args()
 
     if args.mode == 'link':


### PR DESCRIPTION
This was an older change I made in December that I forgot to put up for review. I went through and addressed some of the more significant lints that `pylint` gave me. I also added a `new` flag that will call out to the `create_repo` function when it is implemented.